### PR TITLE
Modify splash screen auto-hide behavior

### DIFF
--- a/android/src/main/java/org/devio/rn/splashscreen/SplashScreen.kt
+++ b/android/src/main/java/org/devio/rn/splashscreen/SplashScreen.kt
@@ -60,13 +60,16 @@ object SplashScreen {
                         val animationDuration = (System.currentTimeMillis() - animationStartTime) / 1000.0
                         setAnimationFinished(true)
 
-                        if (animationDuration > 0.5) {
-                            hideSplashScreen()
-                        } else {
-                            // Wait for minimum duration
-                            lottie?.postDelayed({
+                        // Only auto-hide if not forced to keep splash until explicit hide() is called
+                        if (!forceToCloseByHideMethod) {
+                            if (animationDuration > 0.5) {
                                 hideSplashScreen()
-                            }, ((2.0 - animationDuration) * 1000).toLong())
+                            } else {
+                                // Wait for minimum duration
+                                lottie?.postDelayed({
+                                    hideSplashScreen()
+                                }, ((2.0 - animationDuration) * 1000).toLong())
+                            }
                         }
                     }
 

--- a/android/src/main/java/org/devio/rn/splashscreen/SplashScreenModule.kt
+++ b/android/src/main/java/org/devio/rn/splashscreen/SplashScreenModule.kt
@@ -23,6 +23,8 @@ class SplashScreenModule(reactContext: ReactApplicationContext) : ReactContextBa
      */
     @ReactMethod
     fun hide() {
-        SplashScreen.hide(currentActivity)
+        // Safely retrieves the Activity (nullable) and passes it to hide()
+        val activity = reactApplicationContext.currentActivity
+        SplashScreen.hide(activity)
     }
 }

--- a/ios/RNSplashScreen.swift
+++ b/ios/RNSplashScreen.swift
@@ -75,14 +75,19 @@ public class SplashScreen: NSObject, RCTBridgeModule {
             lottieView.play { finished in
                 DispatchQueue.main.async {
                     isAnimationFinished = true
-                    hideSplashScreen()
+                    // Only auto-hide if not forced to keep splash until explicit hide() is called
+                    if !forceToCloseByHideMethod {
+                        hideSplashScreen()
+                    }
                 }
             }
         } else {
             // Fallback for non-Lottie views
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 isAnimationFinished = true
-                hideSplashScreen()
+                if !forceToCloseByHideMethod {
+                    hideSplashScreen()
+                }
             }
         }
     }


### PR DESCRIPTION
-- iOS
Added a condition to only auto-hide the splash screen if not forced to keep it visible until an explicit hide() is called.

-- Android
Add compatibility with RN 0.81 / Safely retrieves the Activity (nullable) and passes it to hide() 